### PR TITLE
Fix error during upgrade

### DIFF
--- a/plugins/filter/warpwire/filter.php
+++ b/plugins/filter/warpwire/filter.php
@@ -22,6 +22,11 @@ class filter_warpwire extends moodle_text_filter
     {
         global $COURSE, $PAGE, $CFG, $USER;
 
+        // If upgrade is running, skip this filter. This filter relies on library functions that will throw an error if called during an upgrade.
+        if(!empty($CFG->upgraderunning)){
+            return $text;
+        }
+
         // iframe template element
         $iframe_template = '<iframe 
           width="WIDTH"


### PR DESCRIPTION
get_fast_modinfo() will throw an exception when called during an upgrade. Because filter_warpwire is dependent on it, the filter needs to be skipped if an upgrade is in progress.